### PR TITLE
Add autonomous Career Agent: resume-to-interview-prep pipeline

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -123,6 +123,20 @@ def create_app():
                 created_at   TEXT    NOT NULL DEFAULT (datetime('now'))
             )
         """)
+        # Migration: ensure career_agent_runs table exists for existing databases
+        _db.execute("""
+            CREATE TABLE IF NOT EXISTS career_agent_runs (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id         INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                resume_id       INTEGER REFERENCES resumes(id),
+                role            TEXT    NOT NULL DEFAULT '',
+                company         TEXT    NOT NULL DEFAULT '',
+                job_description TEXT    NOT NULL DEFAULT '',
+                steps_json      TEXT    NOT NULL,
+                result_json     TEXT    NOT NULL,
+                created_at      TEXT    NOT NULL DEFAULT (datetime('now'))
+            )
+        """)
         _interview_cols = {
             row[1] for row in _db.execute("PRAGMA table_info(interviews)").fetchall()
         }
@@ -177,5 +191,9 @@ def create_app():
     # Job Applications routes (/api/v1/applications/*)
     from .features.job_applications.api import bp as applications_bp
     app.register_blueprint(applications_bp)
+
+    # Career Agent routes (/api/v1/career-agent/*)
+    from .features.career_agent.api import bp as career_agent_bp
+    app.register_blueprint(career_agent_bp)
 
     return app

--- a/backend/app/features/career_agent/__init__.py
+++ b/backend/app/features/career_agent/__init__.py
@@ -1,0 +1,1 @@
+# backend/app/features/career_agent/__init__.py

--- a/backend/app/features/career_agent/api.py
+++ b/backend/app/features/career_agent/api.py
@@ -1,0 +1,97 @@
+# backend/app/features/career_agent/api.py
+from flask import Blueprint, request, jsonify, current_app
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from ...common.wire import get_db_conn
+from .service import CareerAgentDAO, run_career_agent
+
+bp = Blueprint("career_agent", __name__, url_prefix="/api/v1/career-agent")
+
+
+def _current_user_id() -> int:
+    uid = get_jwt_identity()
+    if uid is None:
+        raise PermissionError("No JWT identity found")
+    try:
+        return int(uid)
+    except (ValueError, TypeError) as e:
+        raise ValueError(f"Invalid user ID format: {uid}") from e
+
+
+@bp.post("/run")
+@jwt_required()
+def run_agent():
+    conn = None
+    try:
+        user_id = _current_user_id()
+        body = request.get_json(silent=True) or {}
+
+        job_description = (body.get("job_description") or "").strip()
+        role = (body.get("role") or "").strip()
+        company = (body.get("company") or "").strip()
+
+        if not job_description:
+            return jsonify({"error": "job_description is required"}), 400
+
+        conn = get_db_conn()
+        result = run_career_agent(conn, user_id, job_description, role, company)
+        return jsonify(result), 201
+    except PermissionError as e:
+        return jsonify({"error": "Authentication required", "message": str(e)}), 401
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 404
+    except Exception as e:
+        current_app.logger.error(f"Error running career agent: {e}", exc_info=True)
+        return jsonify({"error": "Internal server error"}), 500
+    finally:
+        if conn:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
+@bp.get("/runs")
+@jwt_required()
+def list_runs():
+    conn = None
+    try:
+        user_id = _current_user_id()
+        conn = get_db_conn()
+        runs = CareerAgentDAO(conn).list_runs(user_id)
+        return jsonify({"runs": runs}), 200
+    except PermissionError as e:
+        return jsonify({"error": "Authentication required", "message": str(e)}), 401
+    except Exception as e:
+        current_app.logger.error(f"Error listing career agent runs: {e}", exc_info=True)
+        return jsonify({"error": "Internal server error"}), 500
+    finally:
+        if conn:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
+@bp.get("/runs/<int:run_id>")
+@jwt_required()
+def get_run(run_id: int):
+    conn = None
+    try:
+        user_id = _current_user_id()
+        conn = get_db_conn()
+        run = CareerAgentDAO(conn).get_run(run_id, user_id)
+        if run is None:
+            return jsonify({"error": "Run not found"}), 404
+        return jsonify(run), 200
+    except PermissionError as e:
+        return jsonify({"error": "Authentication required", "message": str(e)}), 401
+    except Exception as e:
+        current_app.logger.error(f"Error fetching career agent run: {e}", exc_info=True)
+        return jsonify({"error": "Internal server error"}), 500
+    finally:
+        if conn:
+            try:
+                conn.close()
+            except Exception:
+                pass

--- a/backend/app/features/career_agent/service.py
+++ b/backend/app/features/career_agent/service.py
@@ -1,0 +1,262 @@
+# backend/app/features/career_agent/service.py
+"""
+Autonomous multi-step "Career Agent": chains resume analysis, job-fit gap
+analysis, cover letter drafting, and interview prep into a single run, with
+branching decisions based on what it discovers about the candidate along the
+way (not just a fixed sequence of calls).
+"""
+
+from datetime import datetime, timezone
+import json
+
+from ...services.ai_helper import AIHelper
+from ...services.keyword_match import compute_lightweight_match
+from ..progress.service import award_resume_score
+
+
+class CareerAgentDAO:
+    def __init__(self, conn):
+        self.conn = conn
+
+    def latest_resume(self, user_id: int):
+        row = self.conn.execute(
+            """
+            SELECT id, parsed_json
+            FROM resumes
+            WHERE user_id = ?
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            (user_id,),
+        ).fetchone()
+        return dict(row) if row else None
+
+    def save_run(
+        self,
+        user_id: int,
+        resume_id: int,
+        role: str,
+        company: str,
+        job_description: str,
+        steps: list,
+        result: dict,
+    ) -> int:
+        cursor = self.conn.execute(
+            """
+            INSERT INTO career_agent_runs
+                (user_id, resume_id, role, company, job_description, steps_json, result_json)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                user_id,
+                resume_id,
+                role,
+                company,
+                job_description,
+                json.dumps(steps),
+                json.dumps(result),
+            ),
+        )
+        self.conn.commit()
+        return cursor.lastrowid
+
+    def list_runs(self, user_id: int, limit: int = 20) -> list[dict]:
+        rows = self.conn.execute(
+            """
+            SELECT id, role, company, created_at, result_json
+            FROM career_agent_runs
+            WHERE user_id = ?
+            ORDER BY created_at DESC
+            LIMIT ?
+            """,
+            (user_id, limit),
+        ).fetchall()
+
+        summaries = []
+        for row in rows:
+            try:
+                result = json.loads(row["result_json"] or "{}")
+            except json.JSONDecodeError:
+                result = {}
+            summaries.append({
+                "id": row["id"],
+                "role": row["role"],
+                "company": row["company"],
+                "created_at": row["created_at"],
+                "resume_score": (result.get("resume_analysis") or {}).get("score"),
+                "fit_score": (result.get("match_analysis") or {}).get("score"),
+            })
+        return summaries
+
+    def get_run(self, run_id: int, user_id: int):
+        row = self.conn.execute(
+            """
+            SELECT id, role, company, job_description, steps_json, result_json, created_at
+            FROM career_agent_runs
+            WHERE id = ? AND user_id = ?
+            """,
+            (run_id, user_id),
+        ).fetchone()
+        if not row:
+            return None
+
+        try:
+            steps = json.loads(row["steps_json"] or "[]")
+        except json.JSONDecodeError:
+            steps = []
+        try:
+            result = json.loads(row["result_json"] or "{}")
+        except json.JSONDecodeError:
+            result = {}
+
+        return {
+            "id": row["id"],
+            "role": row["role"],
+            "company": row["company"],
+            "job_description": row["job_description"],
+            "created_at": row["created_at"],
+            "steps": steps,
+            **result,
+        }
+
+
+def _load_parsed_resume(parsed_json_str: str) -> dict:
+    try:
+        return json.loads(parsed_json_str or "{}")
+    except json.JSONDecodeError:
+        return {}
+
+
+def _resume_full_text(parsed_resume: dict) -> str:
+    for section in (parsed_resume.get("sections") or []):
+        if section.get("name") == "full_content":
+            return section.get("content") or ""
+    return parsed_resume.get("raw_text") or ""
+
+
+class _AgentTrace:
+    """Records each autonomous step in order, so a run can be inspected end-to-end."""
+
+    def __init__(self):
+        self.steps: list[dict] = []
+
+    def record(self, step: str, detail: str) -> None:
+        self.steps.append({
+            "step": step,
+            "status": "done",
+            "detail": detail,
+            "at": datetime.now(timezone.utc).isoformat(),
+        })
+
+
+def run_career_agent(
+    conn,
+    user_id: int,
+    job_description: str,
+    role: str = "",
+    company: str = "",
+) -> dict:
+    """
+    Runs the full agent pipeline for the user's most recent resume:
+      1. load resume -> 2. score resume -> 3. gap analysis vs job_description ->
+      4. adapt the plan based on scores -> 5. draft cover letter -> 6. build interview prep.
+    Raises ValueError if there is no usable resume on file.
+    """
+    dao = CareerAgentDAO(conn)
+    ai_helper = AIHelper()
+    trace = _AgentTrace()
+
+    resume_row = dao.latest_resume(user_id)
+    if not resume_row:
+        raise ValueError("No resume found. Upload a resume before running the career agent.")
+
+    parsed_resume = _load_parsed_resume(resume_row["parsed_json"])
+    resume_text = _resume_full_text(parsed_resume)
+    if not resume_text.strip():
+        raise ValueError("The stored resume has no readable text to analyze.")
+    extracted_data = parsed_resume.get("extracted_data") or {}
+    trace.record("load_resume", f"Loaded resume #{resume_row['id']} for analysis.")
+
+    resume_evaluation = ai_helper.scoreResume(parsed_resume)
+    trace.record("score_resume", f"Resume scored {resume_evaluation['score']}/100.")
+
+    match_result = compute_lightweight_match(resume_text, job_description or "")
+    trace.record(
+        "gap_analysis",
+        f"Job-fit score {round(match_result['score'] * 100)}%, "
+        f"{len(match_result['missing_keywords'])} missing keywords identified.",
+    )
+
+    # Decision point: the plan adapts to what the agent just learned instead of
+    # running a fixed script regardless of the candidate's actual standing.
+    decisions = []
+    if resume_evaluation["score"] < 60:
+        decisions.append(
+            "Resume score is on the low side, so the cover letter leans on the strongest "
+            "matched skills rather than general resume framing, and prep adds an extra question."
+        )
+    if match_result["score"] < 0.4:
+        decisions.append(
+            "Job-fit score is low, so interview prep prioritizes bridging the largest "
+            "keyword gaps over general behavioral questions."
+        )
+    else:
+        decisions.append(
+            "Job-fit score is solid, so interview prep emphasizes differentiation on top "
+            "of covering the remaining gaps."
+        )
+    trace.record("plan_adjustment", " ".join(decisions))
+
+    cover_letter = ai_helper.generateCoverLetter(
+        extracted_data,
+        role,
+        company,
+        job_description or "",
+        match_result["matched_keywords"],
+        match_result["missing_keywords"],
+    )
+    trace.record("draft_cover_letter", "Drafted a tailored cover letter grounded in resume evidence.")
+
+    prep_plan = ai_helper.generateInterviewPrepPlan(
+        role,
+        company,
+        match_result["missing_keywords"],
+        resume_evaluation["score"],
+    )
+    trace.record(
+        "build_interview_prep",
+        f"Built prep plan with {len(prep_plan['focus_areas'])} focus areas "
+        f"and {len(prep_plan['questions'])} questions.",
+    )
+
+    result = {
+        "resume_analysis": {
+            "score": resume_evaluation["score"],
+            "summary": resume_evaluation["summary"],
+            "suggestions": resume_evaluation["details"].get("suggestions", []),
+        },
+        "match_analysis": match_result,
+        "decisions": decisions,
+        "cover_letter": cover_letter,
+        "interview_prep": prep_plan,
+    }
+
+    run_id = dao.save_run(
+        user_id,
+        int(resume_row["id"]),
+        role,
+        company,
+        job_description or "",
+        trace.steps,
+        result,
+    )
+
+    # Reuse the same progress hook a direct resume upload triggers, so a
+    # career-agent run contributes to the existing gamified progress too.
+    award_resume_score(user_id, int(resume_evaluation["score"]))
+
+    return {
+        "run_id": run_id,
+        "steps": trace.steps,
+        **result,
+    }

--- a/backend/app/features/keywords/api.py
+++ b/backend/app/features/keywords/api.py
@@ -6,10 +6,10 @@ import time
 from urllib.request import urlopen, Request
 from urllib.error import URLError
 from html import unescape
-from functools import lru_cache
 
 from ... import db  # Import the db module from the app's root
 from ..progress.service import award_resume_score  # ✅ add progress award
+from ...services.keyword_match import compute_lightweight_match
 
 # This blueprint is already registered in your __init__.py
 bp = Blueprint("keywords", __name__, url_prefix="/api/keywords")
@@ -17,15 +17,6 @@ bp = Blueprint("keywords", __name__, url_prefix="/api/keywords")
 SIMPLIFY_README_URL = "https://raw.githubusercontent.com/SimplifyJobs/New-Grad-Positions/dev/README.md"
 JOBS_CACHE_TTL_SECONDS = 60 * 30
 _jobs_cache = {"jobs": [], "fetched_at": 0}
-SEMANTIC_MATCH_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
-ENGLISH_STOP_WORDS = {
-    "a", "an", "and", "are", "as", "at", "be", "by", "for", "from", "has",
-    "he", "in", "is", "it", "its", "of", "on", "that", "the", "to", "was",
-    "were", "will", "with", "or", "this", "these", "those", "your", "you",
-    "our", "we", "they", "their", "them", "i", "me", "my", "mine", "but",
-    "if", "then", "than", "into", "over", "under", "after", "before", "up",
-    "down", "out", "about", "not", "no", "so", "too", "very", "can"
-}
 
 
 def _strip_html(text: str) -> str:
@@ -170,108 +161,6 @@ def _fetch_job_details(simplify_url: str) -> dict:
     }
 
 
-def _tokenize_keywords(text: str) -> set[str]:
-    return {
-        token
-        for token in re.findall(r"[a-zA-Z][a-zA-Z0-9+#.\-]{2,}", (text or "").lower())
-        if len(token) > 2 and token not in ENGLISH_STOP_WORDS
-    }
-
-
-def _split_text_chunks(text: str, max_chunks: int = 18) -> list[str]:
-    raw_parts = re.split(r"\n+|(?<=[.!?])\s+", text or "")
-    chunks: list[str] = []
-
-    for part in raw_parts:
-        cleaned = re.sub(r"\s+", " ", part).strip(" -•\t")
-        if len(cleaned) < 30:
-            continue
-        chunks.append(cleaned)
-        if len(chunks) >= max_chunks:
-            break
-
-    return chunks
-
-
-@lru_cache(maxsize=1)
-def _load_sentence_transformer():
-    from sentence_transformers import SentenceTransformer
-
-    return SentenceTransformer(SEMANTIC_MATCH_MODEL, local_files_only=True)
-
-
-def _compute_hybrid_match(resume_text: str, job_description: str) -> dict:
-    model = _load_sentence_transformer()
-
-    resume_keywords = _tokenize_keywords(resume_text)
-    jd_keywords = _tokenize_keywords(job_description)
-    shared_keywords = sorted(resume_keywords.intersection(jd_keywords))
-    missing_keywords = sorted(jd_keywords.difference(resume_keywords))
-
-    resume_chunks = _split_text_chunks(resume_text)
-    job_chunks = _split_text_chunks(job_description)
-
-    # Fall back to whole-document comparison if chunking produced little signal.
-    resume_inputs = resume_chunks or [resume_text]
-    job_inputs = job_chunks or [job_description]
-
-    resume_embeddings = model.encode(resume_inputs, normalize_embeddings=True).tolist()
-    job_embeddings = model.encode(job_inputs, normalize_embeddings=True).tolist()
-
-    similarity_matrix = []
-    for job_vector in job_embeddings:
-        row = []
-        for resume_vector in resume_embeddings:
-            row.append(sum(a * b for a, b in zip(job_vector, resume_vector)))
-        similarity_matrix.append(row)
-
-    best_scores = [max(row) for row in similarity_matrix] if similarity_matrix else [0.0]
-    chunk_coverage = (
-        sum(1 for score in best_scores if score >= 0.35) / len(best_scores)
-        if best_scores else 0.0
-    )
-    semantic_score = sum(best_scores) / len(best_scores) if best_scores else 0.0
-
-    # Keep some lexical grounding so users still get actionable keyword feedback.
-    lexical_overlap = (
-        len(shared_keywords) / len(jd_keywords)
-        if jd_keywords
-        else 0.0
-    )
-
-    final_score = max(0.0, min(1.0, semantic_score * 0.7 + lexical_overlap * 0.3))
-
-    top_matches = []
-    if similarity_matrix:
-        ranked_job_indices = sorted(
-            range(len(best_scores)),
-            key=lambda idx: best_scores[idx],
-            reverse=True,
-        )[:3]
-        for job_idx in ranked_job_indices:
-            resume_idx = max(
-                range(len(similarity_matrix[job_idx])),
-                key=lambda idx: similarity_matrix[job_idx][idx],
-            )
-            top_matches.append({
-                "job_excerpt": job_inputs[job_idx],
-                "resume_excerpt": resume_inputs[resume_idx],
-                "score": float(best_scores[job_idx]),
-            })
-
-    return {
-        "score": final_score,
-        "semantic_score": semantic_score,
-        "lexical_overlap": lexical_overlap,
-        "coverage_score": chunk_coverage,
-        "matched_keywords": shared_keywords[:30],
-        "missing_keywords": missing_keywords[:30],
-        "top_matches": top_matches,
-        "method": "sentence-transformers-hybrid",
-        "model": SEMANTIC_MATCH_MODEL,
-    }
-
-
 def _load_new_grad_jobs(force_refresh: bool = False) -> list[dict]:
     now = time.time()
     if (
@@ -292,67 +181,6 @@ def _load_new_grad_jobs(force_refresh: bool = False) -> list[dict]:
     _jobs_cache["jobs"] = jobs
     _jobs_cache["fetched_at"] = now
     return jobs
-
-
-def _compute_lightweight_match(resume_text: str, job_description: str) -> dict:
-    resume_keywords = _tokenize_keywords(resume_text)
-    jd_keywords = _tokenize_keywords(job_description)
-    shared_keywords = sorted(resume_keywords.intersection(jd_keywords))
-    missing_keywords = sorted(jd_keywords.difference(resume_keywords))
-
-    lexical_overlap = (
-        len(shared_keywords) / len(jd_keywords)
-        if jd_keywords else 0.0
-    )
-
-    resume_chunks = _split_text_chunks(resume_text, max_chunks=12) or [resume_text]
-    job_chunks = _split_text_chunks(job_description, max_chunks=12) or [job_description]
-
-    chunk_scores = []
-    top_matches = []
-    for job_chunk in job_chunks:
-        job_chunk_tokens = _tokenize_keywords(job_chunk)
-        best_score = 0.0
-        best_resume_chunk = resume_chunks[0] if resume_chunks else ""
-
-        for resume_chunk in resume_chunks:
-            resume_chunk_tokens = _tokenize_keywords(resume_chunk)
-            if not job_chunk_tokens:
-                score = 0.0
-            else:
-                score = len(job_chunk_tokens.intersection(resume_chunk_tokens)) / len(job_chunk_tokens)
-
-            if score > best_score:
-                best_score = score
-                best_resume_chunk = resume_chunk
-
-        chunk_scores.append(best_score)
-        top_matches.append({
-            "job_excerpt": job_chunk,
-            "resume_excerpt": best_resume_chunk,
-            "score": round(best_score, 4),
-        })
-
-    coverage_score = (
-        sum(1 for score in chunk_scores if score >= 0.35) / len(chunk_scores)
-        if chunk_scores else 0.0
-    )
-    semantic_score = sum(chunk_scores) / len(chunk_scores) if chunk_scores else lexical_overlap
-    final_score = max(0.0, min(1.0, semantic_score * 0.7 + lexical_overlap * 0.3))
-
-    top_matches = sorted(top_matches, key=lambda item: item["score"], reverse=True)[:3]
-
-    return {
-        "score": round(final_score, 4),
-        "semantic_score": round(semantic_score, 4),
-        "lexical_overlap": round(lexical_overlap, 4),
-        "coverage_score": round(coverage_score, 4),
-        "matched_keywords": shared_keywords[:30],
-        "missing_keywords": missing_keywords[:30],
-        "top_matches": top_matches,
-        "method": "lightweight-keyword-match",
-        "model": None,
-    }
 
 
 @bp.get("/jobs/new-grad")
@@ -484,7 +312,7 @@ def match_keywords():
         except Exception as e:
             return jsonify({"message": f"Error parsing resume JSON: {str(e)}"}), 500
 
-        match_result = _compute_lightweight_match(resume_text, job_description)
+        match_result = compute_lightweight_match(resume_text, job_description)
         score = float(match_result["score"])
         semantic_score = float(match_result["semantic_score"])
         lexical_overlap = float(match_result["lexical_overlap"])

--- a/backend/app/services/ai_helper.py
+++ b/backend/app/services/ai_helper.py
@@ -823,3 +823,164 @@ Resume text:
                 "suggestions": suggestions[:6],
             },
         }
+
+    def generateCoverLetter(
+        self,
+        extracted_data: dict,
+        role: str,
+        company: str,
+        job_description: str,
+        matched_keywords: list[str],
+        missing_keywords: list[str],
+    ) -> dict:
+        """
+        Generate a tailored cover letter grounded in the candidate's actual
+        resume data plus the strengths/gaps found during job matching.
+        """
+        extracted_data = extracted_data or {}
+        name = extracted_data.get("name") or "the candidate"
+        skills = extracted_data.get("skills") or []
+        work_experience = extracted_data.get("work_experience") or []
+        role_text = role or "the role"
+        company_text = company or "your company"
+
+        if self.model:
+            try:
+                prompt = f"""
+                Write a concise, specific, and honest cover letter for {name} applying to the
+                {role_text} role at {company_text}.
+
+                Candidate skills: {", ".join(skills[:15]) or "not specified"}
+                Candidate work experience: {json.dumps(work_experience[:3])}
+                Job description excerpt: {(job_description or "")[:1500]}
+                Keywords the candidate's resume already covers (lean on these): {", ".join(matched_keywords[:12]) or "none detected"}
+                Keywords missing from the resume (do NOT claim these as experience; at most acknowledge willingness to learn): {", ".join(missing_keywords[:8]) or "none"}
+
+                Requirements:
+                - 3 short paragraphs, no more than 220 words total.
+                - Open by naming the role and company.
+                - Ground every claim in the candidate's real skills/experience above. Never invent experience.
+                - Do not use generic filler like "team player" or "hard worker" without a concrete example.
+
+                Return ONLY a JSON object with these exact keys:
+                - cover_letter: the full letter as a single string with "\\n\\n" between paragraphs
+                - highlighted_strengths: an array of 2-3 short strings naming which real strengths were emphasized
+
+                Do not wrap the JSON in markdown code blocks.
+                """
+                response = self.model.generate_content(prompt)
+                content = self._clean_json_text(response.text)
+                parsed = json.loads(content)
+                letter = str(parsed.get("cover_letter", "")).strip()
+                if letter:
+                    strengths = parsed.get("highlighted_strengths")
+                    return {
+                        "cover_letter": letter,
+                        "highlighted_strengths": [str(s).strip() for s in strengths][:3]
+                        if isinstance(strengths, list) and strengths
+                        else matched_keywords[:3],
+                        "evaluator": {"provider": "gemini", "method": "llm_draft"},
+                    }
+            except Exception as e:
+                print(f"❌ Gemini Cover Letter Error: {e}. Falling back to template.")
+
+        return self._template_cover_letter(
+            name, skills, work_experience, role_text, company_text, matched_keywords
+        )
+
+    def _template_cover_letter(
+        self, name, skills, work_experience, role_text, company_text, matched_keywords
+    ) -> dict:
+        top_skills = matched_keywords[:3] or skills[:3]
+        recent_role = work_experience[0] if work_experience else None
+
+        opening = f"I am writing to apply for the {role_text} position at {company_text}."
+        if recent_role and recent_role.get("role"):
+            middle = (
+                f"In my role as {recent_role.get('role')} at {recent_role.get('company', 'my previous team')}, "
+                f"I built hands-on experience with {', '.join(top_skills) or 'the core skills this role requires'}. "
+                "I am confident that background translates directly into impact on your team."
+            )
+        else:
+            middle = (
+                f"My background includes {', '.join(top_skills) or 'skills directly relevant to this role'}, "
+                "which I am eager to bring to your team."
+            )
+        closing = (
+            f"I would welcome the opportunity to discuss how my experience can contribute to "
+            f"{company_text}'s goals. Thank you for your time and consideration."
+        )
+
+        return {
+            "cover_letter": "\n\n".join([opening, middle, closing]),
+            "highlighted_strengths": top_skills or ["Relevant technical background"],
+            "evaluator": {"provider": "heuristic", "method": "template"},
+        }
+
+    def generateInterviewPrepPlan(
+        self,
+        role: str,
+        company: str,
+        missing_keywords: list[str],
+        resume_score: int = 0,
+    ) -> dict:
+        """
+        Build a prioritized prep plan: focus areas derived from job-match gaps,
+        plus a fresh set of interview questions for the role.
+        """
+        top_gaps = (missing_keywords or [])[:5]
+        role_text = role or "this role"
+        company_text = company or "the company"
+
+        focus_areas = None
+        if self.model and top_gaps:
+            try:
+                prompt = f"""
+                A candidate is preparing for a {role_text} interview at {company_text}.
+                Their resume is missing these keywords found in the job description: {", ".join(top_gaps)}.
+
+                For each keyword, explain briefly why it likely matters to the interviewer and how the
+                candidate should prepare to address it (even if they lack direct professional experience).
+
+                Return ONLY a JSON array, one object per keyword, with these exact keys:
+                - keyword: the keyword
+                - why_it_matters: one short sentence
+                - how_to_prepare: one short, actionable sentence
+                """
+                response = self.model.generate_content(prompt)
+                content = self._clean_json_text(response.text)
+                parsed = json.loads(content)
+                if isinstance(parsed, list) and parsed:
+                    focus_areas = [
+                        {
+                            "keyword": str(item.get("keyword", "")).strip(),
+                            "why_it_matters": str(item.get("why_it_matters", "")).strip(),
+                            "how_to_prepare": str(item.get("how_to_prepare", "")).strip(),
+                        }
+                        for item in parsed
+                        if isinstance(item, dict) and item.get("keyword")
+                    ]
+            except Exception as e:
+                print(f"❌ Gemini Interview Prep Error: {e}. Falling back to template focus areas.")
+
+        if not focus_areas:
+            focus_areas = [
+                {
+                    "keyword": keyword,
+                    "why_it_matters": f"'{keyword}' appears in the job description but wasn't found in the resume, so interviewers may probe it directly.",
+                    "how_to_prepare": f"Prepare one concrete example (even academic or self-taught) showing exposure to {keyword}.",
+                }
+                for keyword in top_gaps
+            ]
+
+        question_count = 6 if resume_score and resume_score < 70 else 5
+        questions = self.generateInterviewQuestions(role_text, company_text, question_count)
+
+        return {
+            "focus_areas": focus_areas,
+            "questions": questions,
+            "evaluator": {
+                "provider": "gemini" if self.model and top_gaps else "heuristic",
+                "method": "llm_gap_analysis" if self.model and top_gaps else "template",
+            },
+        }

--- a/backend/app/services/keyword_match.py
+++ b/backend/app/services/keyword_match.py
@@ -1,0 +1,182 @@
+# backend/app/services/keyword_match.py
+"""Shared resume/job-description matching helpers.
+
+Used by the keywords feature (manual job description paste) and the
+career_agent feature (automated gap analysis step) so both stay in sync.
+"""
+
+import re
+from functools import lru_cache
+
+SEMANTIC_MATCH_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+ENGLISH_STOP_WORDS = {
+    "a", "an", "and", "are", "as", "at", "be", "by", "for", "from", "has",
+    "he", "in", "is", "it", "its", "of", "on", "that", "the", "to", "was",
+    "were", "will", "with", "or", "this", "these", "those", "your", "you",
+    "our", "we", "they", "their", "them", "i", "me", "my", "mine", "but",
+    "if", "then", "than", "into", "over", "under", "after", "before", "up",
+    "down", "out", "about", "not", "no", "so", "too", "very", "can"
+}
+
+
+def tokenize_keywords(text: str) -> set[str]:
+    return {
+        token
+        for token in re.findall(r"[a-zA-Z][a-zA-Z0-9+#.\-]{2,}", (text or "").lower())
+        if len(token) > 2 and token not in ENGLISH_STOP_WORDS
+    }
+
+
+def split_text_chunks(text: str, max_chunks: int = 18) -> list[str]:
+    raw_parts = re.split(r"\n+|(?<=[.!?])\s+", text or "")
+    chunks: list[str] = []
+
+    for part in raw_parts:
+        cleaned = re.sub(r"\s+", " ", part).strip(" -•\t")
+        if len(cleaned) < 30:
+            continue
+        chunks.append(cleaned)
+        if len(chunks) >= max_chunks:
+            break
+
+    return chunks
+
+
+@lru_cache(maxsize=1)
+def _load_sentence_transformer():
+    from sentence_transformers import SentenceTransformer
+
+    return SentenceTransformer(SEMANTIC_MATCH_MODEL, local_files_only=True)
+
+
+def compute_hybrid_match(resume_text: str, job_description: str) -> dict:
+    model = _load_sentence_transformer()
+
+    resume_keywords = tokenize_keywords(resume_text)
+    jd_keywords = tokenize_keywords(job_description)
+    shared_keywords = sorted(resume_keywords.intersection(jd_keywords))
+    missing_keywords = sorted(jd_keywords.difference(resume_keywords))
+
+    resume_chunks = split_text_chunks(resume_text)
+    job_chunks = split_text_chunks(job_description)
+
+    # Fall back to whole-document comparison if chunking produced little signal.
+    resume_inputs = resume_chunks or [resume_text]
+    job_inputs = job_chunks or [job_description]
+
+    resume_embeddings = model.encode(resume_inputs, normalize_embeddings=True).tolist()
+    job_embeddings = model.encode(job_inputs, normalize_embeddings=True).tolist()
+
+    similarity_matrix = []
+    for job_vector in job_embeddings:
+        row = []
+        for resume_vector in resume_embeddings:
+            row.append(sum(a * b for a, b in zip(job_vector, resume_vector)))
+        similarity_matrix.append(row)
+
+    best_scores = [max(row) for row in similarity_matrix] if similarity_matrix else [0.0]
+    chunk_coverage = (
+        sum(1 for score in best_scores if score >= 0.35) / len(best_scores)
+        if best_scores else 0.0
+    )
+    semantic_score = sum(best_scores) / len(best_scores) if best_scores else 0.0
+
+    # Keep some lexical grounding so users still get actionable keyword feedback.
+    lexical_overlap = (
+        len(shared_keywords) / len(jd_keywords)
+        if jd_keywords
+        else 0.0
+    )
+
+    final_score = max(0.0, min(1.0, semantic_score * 0.7 + lexical_overlap * 0.3))
+
+    top_matches = []
+    if similarity_matrix:
+        ranked_job_indices = sorted(
+            range(len(best_scores)),
+            key=lambda idx: best_scores[idx],
+            reverse=True,
+        )[:3]
+        for job_idx in ranked_job_indices:
+            resume_idx = max(
+                range(len(similarity_matrix[job_idx])),
+                key=lambda idx: similarity_matrix[job_idx][idx],
+            )
+            top_matches.append({
+                "job_excerpt": job_inputs[job_idx],
+                "resume_excerpt": resume_inputs[resume_idx],
+                "score": float(best_scores[job_idx]),
+            })
+
+    return {
+        "score": final_score,
+        "semantic_score": semantic_score,
+        "lexical_overlap": lexical_overlap,
+        "coverage_score": chunk_coverage,
+        "matched_keywords": shared_keywords[:30],
+        "missing_keywords": missing_keywords[:30],
+        "top_matches": top_matches,
+        "method": "sentence-transformers-hybrid",
+        "model": SEMANTIC_MATCH_MODEL,
+    }
+
+
+def compute_lightweight_match(resume_text: str, job_description: str) -> dict:
+    resume_keywords = tokenize_keywords(resume_text)
+    jd_keywords = tokenize_keywords(job_description)
+    shared_keywords = sorted(resume_keywords.intersection(jd_keywords))
+    missing_keywords = sorted(jd_keywords.difference(resume_keywords))
+
+    lexical_overlap = (
+        len(shared_keywords) / len(jd_keywords)
+        if jd_keywords else 0.0
+    )
+
+    resume_chunks = split_text_chunks(resume_text, max_chunks=12) or [resume_text]
+    job_chunks = split_text_chunks(job_description, max_chunks=12) or [job_description]
+
+    chunk_scores = []
+    top_matches = []
+    for job_chunk in job_chunks:
+        job_chunk_tokens = tokenize_keywords(job_chunk)
+        best_score = 0.0
+        best_resume_chunk = resume_chunks[0] if resume_chunks else ""
+
+        for resume_chunk in resume_chunks:
+            resume_chunk_tokens = tokenize_keywords(resume_chunk)
+            if not job_chunk_tokens:
+                score = 0.0
+            else:
+                score = len(job_chunk_tokens.intersection(resume_chunk_tokens)) / len(job_chunk_tokens)
+
+            if score > best_score:
+                best_score = score
+                best_resume_chunk = resume_chunk
+
+        chunk_scores.append(best_score)
+        top_matches.append({
+            "job_excerpt": job_chunk,
+            "resume_excerpt": best_resume_chunk,
+            "score": round(best_score, 4),
+        })
+
+    coverage_score = (
+        sum(1 for score in chunk_scores if score >= 0.35) / len(chunk_scores)
+        if chunk_scores else 0.0
+    )
+    semantic_score = sum(chunk_scores) / len(chunk_scores) if chunk_scores else lexical_overlap
+    final_score = max(0.0, min(1.0, semantic_score * 0.7 + lexical_overlap * 0.3))
+
+    top_matches = sorted(top_matches, key=lambda item: item["score"], reverse=True)[:3]
+
+    return {
+        "score": round(final_score, 4),
+        "semantic_score": round(semantic_score, 4),
+        "lexical_overlap": round(lexical_overlap, 4),
+        "coverage_score": round(coverage_score, 4),
+        "matched_keywords": shared_keywords[:30],
+        "missing_keywords": missing_keywords[:30],
+        "top_matches": top_matches,
+        "method": "lightweight-keyword-match",
+        "model": None,
+    }

--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -139,3 +139,17 @@ CREATE TABLE IF NOT EXISTS job_applications (
   field        TEXT    NOT NULL DEFAULT '',
   created_at   TEXT    NOT NULL DEFAULT (datetime('now'))
 );
+
+-- Autonomous career agent runs (resume analysis -> gap analysis -> cover
+-- letter -> interview prep), stored so users can revisit past runs.
+CREATE TABLE IF NOT EXISTS career_agent_runs (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id         INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  resume_id       INTEGER REFERENCES resumes(id),
+  role            TEXT    NOT NULL DEFAULT '',
+  company         TEXT    NOT NULL DEFAULT '',
+  job_description TEXT    NOT NULL DEFAULT '',
+  steps_json      TEXT    NOT NULL,
+  result_json     TEXT    NOT NULL,
+  created_at      TEXT    NOT NULL DEFAULT (datetime('now'))
+);

--- a/backend/tests/features/career_agent/test_career_agent_api.py
+++ b/backend/tests/features/career_agent/test_career_agent_api.py
@@ -1,0 +1,234 @@
+"""
+Integration tests for the career agent API (run, list, get detail).
+Uses a temporary SQLite DB and mocks AIHelper to avoid external API calls.
+compute_lightweight_match is left unmocked since it is pure Python with no
+external dependencies.
+"""
+import json
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+from backend.app import create_app
+
+
+SAMPLE_RESUME_TEXT = (
+    "Jane Doe. Built and shipped a Python data pipeline. Automated reporting with SQL. "
+    "Led a small team and improved report turnaround by 30 percent. "
+    "Skills: Python, SQL, Data Analysis, Communication."
+)
+
+SAMPLE_JOB_DESCRIPTION = (
+    "We are looking for a Data Analyst with strong Python and SQL skills, experience with "
+    "dashboards, and familiarity with machine learning and cloud infrastructure."
+)
+
+SAMPLE_COVER_LETTER = {
+    "cover_letter": "Dear Hiring Manager,\n\nI built a Python pipeline...\n\nThank you.",
+    "highlighted_strengths": ["python", "sql"],
+    "evaluator": {"provider": "gemini", "method": "llm_draft"},
+}
+
+SAMPLE_PREP_PLAN = {
+    "focus_areas": [
+        {"keyword": "machine", "why_it_matters": "Core to the role.", "how_to_prepare": "Review basics."},
+    ],
+    "questions": [{"id": "q1", "prompt": "Tell me about a data project.", "tags": ["technical"]}],
+    "evaluator": {"provider": "gemini", "method": "llm_gap_analysis"},
+}
+
+SAMPLE_RESUME_EVAL = {
+    "score": 72,
+    "summary": "Solid resume with clear impact.",
+    "details": {"suggestions": ["Add a projects section."]},
+}
+
+
+def _run_schema(conn, schema_path: str):
+    with open(schema_path) as f:
+        conn.executescript(f.read())
+    conn.commit()
+
+
+@pytest.fixture
+def app():
+    """Create app with a temporary database and run schema."""
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    app = create_app()
+    app.config["TESTING"] = True
+    app.config["DATABASE"] = path
+    schema_path = os.path.join(
+        os.path.dirname(__file__), "..", "..", "..", "database", "schema.sql"
+    )
+    with app.app_context():
+        from backend.app.db import get_db
+        with app.test_request_context():
+            conn = get_db()
+            _run_schema(conn, schema_path)
+    yield app
+    try:
+        os.unlink(path)
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def auth_headers(client):
+    """Register a test user, login, return headers with Bearer token."""
+    client.post(
+        "/api/v1/auth/register",
+        data=json.dumps({
+            "email": "careeragent@test.com",
+            "password": "testpass123",
+            "name": "Jane Doe",
+        }),
+        content_type="application/json",
+    )
+    rv = client.post(
+        "/api/v1/auth/login",
+        data=json.dumps({
+            "email": "careeragent@test.com",
+            "password": "testpass123",
+        }),
+        content_type="application/json",
+    )
+    assert rv.status_code == 200
+    data = json.loads(rv.data)
+    token = data.get("accessToken")
+    assert token
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _insert_resume(app, email, resume_text):
+    """Insert a resume row directly, bypassing file upload/parsing."""
+    with app.app_context():
+        from backend.app.db import get_db
+        with app.test_request_context():
+            conn = get_db()
+            user_row = conn.execute(
+                "SELECT id FROM users WHERE email = ?", (email,)
+            ).fetchone()
+            parsed = {
+                "sections": [{"name": "full_content", "content": resume_text}],
+                "extracted_data": {
+                    "name": "Jane Doe",
+                    "skills": ["Python", "SQL"],
+                    "work_experience": [{"company": "Acme", "role": "Analyst"}],
+                },
+            }
+            conn.execute(
+                "INSERT INTO resumes (user_id, file_path, parsed_json) VALUES (?, ?, ?)",
+                (user_row["id"], "/tmp/fake.pdf", json.dumps(parsed)),
+            )
+            conn.commit()
+
+
+def _mock_ai_helper():
+    mock_instance = MagicMock()
+    mock_instance.scoreResume.return_value = SAMPLE_RESUME_EVAL
+    mock_instance.generateCoverLetter.return_value = SAMPLE_COVER_LETTER
+    mock_instance.generateInterviewPrepPlan.return_value = SAMPLE_PREP_PLAN
+    return mock_instance
+
+
+def test_run_agent_unauthorized(client):
+    """POST /run without a token returns 401."""
+    rv = client.post(
+        "/api/v1/career-agent/run",
+        data=json.dumps({"job_description": "x"}),
+        content_type="application/json",
+    )
+    assert rv.status_code == 401
+
+
+@patch("backend.app.features.career_agent.service.AIHelper")
+def test_run_agent_requires_job_description(MockAIHelper, client, auth_headers):
+    MockAIHelper.return_value = _mock_ai_helper()
+    rv = client.post(
+        "/api/v1/career-agent/run",
+        data=json.dumps({"role": "Data Analyst", "company": "Acme"}),
+        content_type="application/json",
+        headers=auth_headers,
+    )
+    assert rv.status_code == 400
+
+
+@patch("backend.app.features.career_agent.service.AIHelper")
+def test_run_agent_without_resume_returns_404(MockAIHelper, client, auth_headers):
+    MockAIHelper.return_value = _mock_ai_helper()
+    rv = client.post(
+        "/api/v1/career-agent/run",
+        data=json.dumps({
+            "job_description": SAMPLE_JOB_DESCRIPTION,
+            "role": "Data Analyst",
+            "company": "Acme",
+        }),
+        content_type="application/json",
+        headers=auth_headers,
+    )
+    assert rv.status_code == 404
+
+
+@patch("backend.app.features.career_agent.service.AIHelper")
+def test_run_agent_full_contract(MockAIHelper, client, app, auth_headers):
+    """Full run: resume analysis -> gap analysis -> cover letter -> prep plan, then list/detail."""
+    MockAIHelper.return_value = _mock_ai_helper()
+    _insert_resume(app, "careeragent@test.com", SAMPLE_RESUME_TEXT)
+
+    rv = client.post(
+        "/api/v1/career-agent/run",
+        data=json.dumps({
+            "job_description": SAMPLE_JOB_DESCRIPTION,
+            "role": "Data Analyst",
+            "company": "Acme",
+        }),
+        content_type="application/json",
+        headers=auth_headers,
+    )
+    assert rv.status_code == 201
+    data = json.loads(rv.data)
+
+    assert "run_id" in data
+    assert [s["step"] for s in data["steps"]] == [
+        "load_resume",
+        "score_resume",
+        "gap_analysis",
+        "plan_adjustment",
+        "draft_cover_letter",
+        "build_interview_prep",
+    ]
+    assert data["resume_analysis"]["score"] == 72
+    assert data["cover_letter"]["cover_letter"] == SAMPLE_COVER_LETTER["cover_letter"]
+    assert data["interview_prep"]["questions"][0]["id"] == "q1"
+    assert "match_analysis" in data and "missing_keywords" in data["match_analysis"]
+    assert isinstance(data["decisions"], list) and data["decisions"]
+
+    list_rv = client.get("/api/v1/career-agent/runs", headers=auth_headers)
+    assert list_rv.status_code == 200
+    runs = json.loads(list_rv.data)["runs"]
+    assert len(runs) == 1
+    assert runs[0]["id"] == data["run_id"]
+    assert runs[0]["resume_score"] == 72
+
+    detail_rv = client.get(f"/api/v1/career-agent/runs/{data['run_id']}", headers=auth_headers)
+    assert detail_rv.status_code == 200
+    detail = json.loads(detail_rv.data)
+    assert detail["role"] == "Data Analyst"
+    assert detail["company"] == "Acme"
+    assert len(detail["steps"]) == 6
+    assert detail["cover_letter"]["cover_letter"] == SAMPLE_COVER_LETTER["cover_letter"]
+
+
+@patch("backend.app.features.career_agent.service.AIHelper")
+def test_get_run_not_found(MockAIHelper, client, auth_headers):
+    """Fetching a run id that doesn't exist (or isn't owned by the user) returns 404."""
+    MockAIHelper.return_value = _mock_ai_helper()
+    rv = client.get("/api/v1/career-agent/runs/99999", headers=auth_headers)
+    assert rv.status_code == 404

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,7 @@ import Register from './components/Register';
 import AccountSettings from './components/AccountSettings';
 import CareerHub from './components/CareerHub';
 import Applications from './components/Applications';
+import CareerAgent from './components/CareerAgent';
 
 function App() {
   const [token, setToken] = useState(localStorage.getItem('token'));
@@ -53,6 +54,7 @@ function App() {
     if (currentPage === 'resume') return <Resume />;
     if (currentPage === 'interview') return <MockInterview />;
     if (currentPage === 'job-match') return <JobMatch />;
+    if (currentPage === 'career-agent') return <CareerAgent />;
     if (currentPage === 'career-hub') return <CareerHub />;
     if (currentPage === 'applications') return <Applications />;
     if (currentPage === 'account-settings') return <AccountSettings />;
@@ -101,6 +103,14 @@ function App() {
                 onClick={() => setCurrentPage('job-match')}
               >
                 Job Match
+              </button>
+              <button
+                className={
+                  currentPage === 'career-agent' ? 'nav-link active' : 'nav-link'
+                }
+                onClick={() => setCurrentPage('career-agent')}
+              >
+                Career Agent
               </button>
               <button
                 className={

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -161,4 +161,13 @@ export const api = {
   // Career Resources endpoints
   getAllResources: () => request('/api/v1/resources'),
   getRecommendedResources: () => request('/api/v1/resources/recommended'),
+
+  // Career Agent endpoints
+  runCareerAgent: (data) =>
+    request('/api/v1/career-agent/run', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  getCareerAgentRuns: () => request('/api/v1/career-agent/runs'),
+  getCareerAgentRun: (runId) => request(`/api/v1/career-agent/runs/${runId}`),
 };

--- a/frontend/src/components/CareerAgent.css
+++ b/frontend/src/components/CareerAgent.css
@@ -1,0 +1,140 @@
+.career-agent-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.career-agent-inline-inputs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.agent-trace {
+  list-style: none;
+  margin: 0 0 1.5rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.agent-trace-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.85rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  padding: 0.85rem 1rem;
+}
+
+.agent-trace-check {
+  flex: 0 0 auto;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: rgba(255, 140, 0, 0.15);
+  border: 1px solid rgba(255, 140, 0, 0.4);
+  color: #FFB347;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  margin-top: 0.1rem;
+}
+
+.agent-trace-label {
+  color: #FFFFFF;
+  font-weight: 700;
+  font-size: 0.92rem;
+}
+
+.agent-trace-detail {
+  color: #BBBBBB;
+  font-size: 0.85rem;
+  margin-top: 0.15rem;
+  line-height: 1.5;
+}
+
+.agent-decisions {
+  background: rgba(255, 140, 0, 0.06);
+  border: 1px solid rgba(255, 140, 0, 0.2);
+  border-radius: 16px;
+  padding: 1rem 1.1rem;
+  margin-bottom: 2rem;
+}
+
+.agent-metrics-grid {
+  margin-bottom: 2rem;
+}
+
+.agent-panel {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.agent-panel h5 {
+  margin: 0 0 1rem;
+  color: #FFFFFF;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.agent-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.agent-panel-header h5 {
+  margin: 0;
+}
+
+.agent-copy-button {
+  width: auto;
+  padding: 0.5rem 1.1rem;
+  flex: 0 0 auto;
+}
+
+.agent-cover-letter {
+  color: #F3F3F3;
+  line-height: 1.7;
+  white-space: pre-wrap;
+  margin: 0;
+}
+
+.agent-focus-areas {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  margin-bottom: 1.25rem;
+}
+
+.agent-question-list {
+  margin: 0;
+}
+
+.agent-run-card {
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.agent-run-card:hover {
+  background: rgba(255, 255, 255, 0.07);
+}
+
+@media (max-width: 768px) {
+  .career-agent-inline-inputs {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/components/CareerAgent.js
+++ b/frontend/src/components/CareerAgent.js
@@ -1,0 +1,266 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { api } from '../api';
+import './CareerAgent.css';
+
+const STEP_LABELS = {
+  load_resume: 'Load resume',
+  score_resume: 'Score resume',
+  gap_analysis: 'Analyze job fit',
+  plan_adjustment: 'Adapt the plan',
+  draft_cover_letter: 'Draft cover letter',
+  build_interview_prep: 'Build interview prep',
+};
+
+const CareerAgent = () => {
+  const [role, setRole] = useState('');
+  const [company, setCompany] = useState('');
+  const [jobDescription, setJobDescription] = useState('');
+  const [isRunning, setIsRunning] = useState(false);
+  const [error, setError] = useState('');
+  const [result, setResult] = useState(null);
+  const [copied, setCopied] = useState(false);
+  const [runs, setRuns] = useState([]);
+  const [runsLoading, setRunsLoading] = useState(true);
+
+  const loadRuns = useCallback(async () => {
+    try {
+      setRunsLoading(true);
+      const data = await api.getCareerAgentRuns();
+      setRuns(data.runs || []);
+    } catch (err) {
+      // Recent-runs history is a nice-to-have; ignore load errors here.
+    } finally {
+      setRunsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadRuns();
+  }, [loadRuns]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setIsRunning(true);
+    setError('');
+    setResult(null);
+    setCopied(false);
+
+    try {
+      const data = await api.runCareerAgent({
+        role,
+        company,
+        job_description: jobDescription,
+      });
+      setResult(data);
+      loadRuns();
+    } catch (err) {
+      setError(err.message || 'The career agent run failed.');
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  const openPastRun = async (runId) => {
+    setError('');
+    setResult(null);
+    setCopied(false);
+    try {
+      const data = await api.getCareerAgentRun(runId);
+      setRole(data.role || '');
+      setCompany(data.company || '');
+      setJobDescription(data.job_description || '');
+      setResult(data);
+    } catch (err) {
+      setError(err.message || 'Could not load that run.');
+    }
+  };
+
+  const copyCoverLetter = async () => {
+    if (!result?.cover_letter?.cover_letter) return;
+    try {
+      await navigator.clipboard.writeText(result.cover_letter.cover_letter);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      // Clipboard access can be blocked by the browser; nothing actionable to do.
+    }
+  };
+
+  return (
+    <div className="career-agent-page">
+      <div className="auth-container career-agent-form" style={{ minHeight: 'unset' }}>
+        <div className="auth-card" style={{ maxWidth: '900px' }}>
+          <h2>Career Agent</h2>
+          <p style={{ color: '#AAAAAA', marginTop: '-1rem', marginBottom: '2rem', textAlign: 'center' }}>
+            One autonomous run: analyzes your latest resume, finds the gaps against a job
+            description, then drafts a tailored cover letter and interview prep plan.
+          </p>
+
+          <form onSubmit={handleSubmit} noValidate>
+            <div className="career-agent-inline-inputs">
+              <div className="input-group">
+                <label htmlFor="agent-role">Role</label>
+                <input
+                  id="agent-role"
+                  className="auth-input"
+                  value={role}
+                  onChange={(e) => setRole(e.target.value)}
+                  placeholder="e.g. Data Analyst"
+                />
+              </div>
+              <div className="input-group">
+                <label htmlFor="agent-company">Company</label>
+                <input
+                  id="agent-company"
+                  className="auth-input"
+                  value={company}
+                  onChange={(e) => setCompany(e.target.value)}
+                  placeholder="e.g. Gauge Capital"
+                />
+              </div>
+            </div>
+
+            <div className="input-group">
+              <label htmlFor="agent-job-description">Job Description</label>
+              <textarea
+                id="agent-job-description"
+                className="auth-textarea"
+                value={jobDescription}
+                onChange={(e) => setJobDescription(e.target.value)}
+                placeholder="Paste the full job description here..."
+                required
+              />
+            </div>
+
+            <div style={{ marginTop: '1.5rem' }}>
+              <button type="submit" className="auth-button" disabled={isRunning}>
+                {isRunning ? 'Running agent...' : 'Run Career Agent'}
+              </button>
+            </div>
+          </form>
+
+          {error && <div className="auth-error">{error}</div>}
+
+          {result && (
+            <div className="results-container agent-results">
+              {result.steps?.length > 0 && (
+                <ol className="agent-trace">
+                  {result.steps.map((step) => (
+                    <li key={step.step} className="agent-trace-item">
+                      <span className="agent-trace-check">✓</span>
+                      <div>
+                        <div className="agent-trace-label">
+                          {STEP_LABELS[step.step] || step.step}
+                        </div>
+                        <div className="agent-trace-detail">{step.detail}</div>
+                      </div>
+                    </li>
+                  ))}
+                </ol>
+              )}
+
+              {result.decisions?.length > 0 && (
+                <div className="agent-decisions">
+                  <span className="match-metric-label">Agent Decisions</span>
+                  <ul className="results-list">
+                    {result.decisions.map((decision, i) => (
+                      <li key={`decision-${i}`} className="results-list-item">
+                        {decision}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              <div className="match-metrics-grid agent-metrics-grid">
+                <div className="match-metric-card">
+                  <span className="match-metric-label">Resume Score</span>
+                  <strong>{result.resume_analysis?.score ?? 0}/100</strong>
+                  <p>{result.resume_analysis?.summary}</p>
+                </div>
+                <div className="match-metric-card">
+                  <span className="match-metric-label">Job Fit</span>
+                  <strong>{Math.round((result.match_analysis?.score || 0) * 100)}%</strong>
+                  <p>Semantic and keyword overlap against the pasted job description.</p>
+                </div>
+                <div className="match-metric-card">
+                  <span className="match-metric-label">Missing Keywords</span>
+                  <strong>{result.match_analysis?.missing_keywords?.length || 0}</strong>
+                  <p>Keywords in the job description not yet reflected in the resume.</p>
+                </div>
+              </div>
+
+              <div className="agent-panel">
+                <div className="agent-panel-header">
+                  <h5>Tailored Cover Letter</h5>
+                  <button type="button" className="auth-button job-secondary-button agent-copy-button" onClick={copyCoverLetter}>
+                    {copied ? 'Copied!' : 'Copy'}
+                  </button>
+                </div>
+                <p className="agent-cover-letter">{result.cover_letter?.cover_letter}</p>
+              </div>
+
+              <div className="agent-panel">
+                <h5>Interview Prep Plan</h5>
+                {result.interview_prep?.focus_areas?.length > 0 && (
+                  <div className="agent-focus-areas">
+                    {result.interview_prep.focus_areas.map((area, i) => (
+                      <div className="match-highlight-card" key={`focus-${i}`}>
+                        <div className="match-highlight-score">{area.keyword}</div>
+                        <p style={{ margin: '0 0 0.5rem' }}>{area.why_it_matters}</p>
+                        <p style={{ margin: 0, color: '#FFB347' }}>{area.how_to_prepare}</p>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                <ul className="results-list agent-question-list">
+                  {(result.interview_prep?.questions || []).map((q) => (
+                    <li key={q.id} className="results-list-item">
+                      {q.prompt}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="auth-container career-agent-history" style={{ minHeight: 'unset', paddingTop: 0 }}>
+        <div className="auth-card" style={{ maxWidth: '900px' }}>
+          <h2>Recent Runs</h2>
+          {runsLoading ? (
+            <p style={{ color: '#AAAAAA', textAlign: 'center' }}>Loading history...</p>
+          ) : runs.length === 0 ? (
+            <p style={{ color: '#AAAAAA', textAlign: 'center' }}>No career agent runs yet.</p>
+          ) : (
+            <div className="job-grid">
+              {runs.map((run) => (
+                <button
+                  type="button"
+                  key={run.id}
+                  className="job-card agent-run-card"
+                  onClick={() => openPastRun(run.id)}
+                >
+                  <div className="job-card-top">
+                    <div>
+                      <div className="job-card-company">{run.company || 'Unnamed company'}</div>
+                      <h3>{run.role || 'Unnamed role'}</h3>
+                    </div>
+                    <span className="job-chip">{run.fit_score != null ? `${Math.round(run.fit_score * 100)}% fit` : '—'}</span>
+                  </div>
+                  <div className="job-card-meta">
+                    <span>Resume score: {run.resume_score ?? '—'}</span>
+                    <span>{run.created_at}</span>
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CareerAgent;


### PR DESCRIPTION
Chains resume scoring, job-fit gap analysis, tailored cover letter drafting, and interview prep into one traced multi-step agent run. The plan adapts based on what it finds (low resume score, weak job fit) instead of following a fixed script, and every run is persisted so users can revisit past runs.

- backend/app/services/keyword_match.py: extracted the tokenize/chunk/ lightweight-match helpers out of the keywords feature so both it and the new career_agent feature share one implementation.
- backend/app/services/ai_helper.py: add generateCoverLetter() and generateInterviewPrepPlan(), following the existing Gemini-with- heuristic-fallback pattern.
- backend/app/features/career_agent/: orchestrates the run, exposes POST /run, GET /runs, GET /runs/<id>, and stores runs in a new career_agent_runs table.
- frontend/src/components/CareerAgent.js: new page showing the agent's step-by-step trace, decisions, cover letter, and interview prep plan, plus a history of past runs.
- backend/tests/features/career_agent/: covers the run/list/detail contract with a mocked AIHelper.